### PR TITLE
Style header and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,7 @@
             </details>
         </nav>
 
-        
-        <h1>How to file a Freedom of Information Law Request in New York State</h1>
+        <h1><span class="title__how-to">How to file</span> <span class="title__connecting">a</span> <span class="title__request">Freedom <span class="title__connecting">of</span> Information Law Request</span> <span class="title__connecting">in</span> <span class="title__place">New York State</span></h1>
 </header>
 
         <dl id="introduction">
@@ -358,26 +357,23 @@ Email
 Phone Number</pre>
             <p class="letter-segment__annotation"></p>
             </div>
-</section>
-            
-  <section class="conclusion">          
+        </section>
+
+        <section class="conclusion">
             <p>If your appeal is rejected, then you can go to court Judicial review of a final agency denial Article 78 of Civial Practice Law and Rules.</p>
 
             <p>FOIL Attorney fees may be awarded to a member of the public <a href="https://www.dos.ny.gov/coog/news/december2017.html">a mandatory fee is rewarded</a> if the court finds that the agency had no reasonable basis for denying access.</p>
-  </section>          
-        
+        </section>
 
-<footer>
+        <footer>
+            <nav class="footer-navigation">
+                <ul>
+                    <li><a href="resources.html">Resources</a></li>
+                    <li><a href="resources.html#about">About this project</a></li>
+                </ul>
+            </nav>
 
-        <div class="footer-navigation"></div>
-            <ul>
-                <li><a href="resources.html">Resources</a></li>
-                <li><a href="resources.html#about">About this project</a></li>
-        </ul>
-
-        <div class = "footer-branding">
-            <p><small><a href="https://astoria.digital/">© Astoria Digital 2020</a></small></p>
-        </div>
+            <p class="copyright"><small><a href="https://astoria.digital/">© Astoria Digital 2020</a></small></p>
         </footer>
 
     </body>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,3 @@
-
-
 /* Typography */
 
 /*
@@ -14,25 +12,37 @@ medium 500 italic
 
 */
 
-html{
+html {
   font-size: 18px;
-}
-
-body {
   font-family: 'DM Mono', Courier, monospace;
 }
 
-h1 {
+h1, h2, h3, h4, h5, h6 {
   font-family: 'Fjalla One', Helvetica, sans-serif;
+}
+
+h1 {
   font-size: 4em;
-  text-transform: uppercase;
-  text-align: center;
+  max-width: 20ch;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.title__how-to {
+  font-variant: small-caps;
+}
+
+.title__connecting {
+  font-size: 0.6em;
+  font-variant: super;
+}
+
+.title__request {
+  text-decoration: underline 0.1ch double currentColor;
 }
 
 h2 {
-  font-family: 'Fjalla One', Helvetica, sans-serif;
   font-size: 3em;
-  font-style: regular;
   font-weight: 300;
   text-transform: uppercase;
   text-align: center;
@@ -106,8 +116,7 @@ ol {
 /* Links */ 
 
 a {
-  text-decoration: none;
-  border-bottom: .1em solid;
+  text-decoration: underline 0.1em solid;
   color: black;
 }
 
@@ -126,16 +135,14 @@ a:focus {
 
 a:hover {
   text-decoration: none;
-  border-bottom: none;
   /* how do i give it a bit of space at the left and right of the word?*/
   color: white;
   background-color: black;
-
 }
 
 a:active {
 
-}   
+}
 
 
 /* Color 
@@ -170,11 +177,6 @@ body {
   padding: 2em;
 }
 
-h1 {
-  padding-bottom: 1em;
-  padding-top: 1em;
-}
-
 h2 {
   padding-bottom: 1em;
   padding-top: 1em;
@@ -186,10 +188,6 @@ li {
 
 header {
   border-bottom: .1em dashed black;
-}
-
-header h1 {
-  text-align: left;
 }
 
 dl {
@@ -304,21 +302,26 @@ header {
 
 footer {
   padding-top: 2em;
-  padding-bottom:1em;
-  border-top: .1em dashed black;      
+  padding-bottom: 1em;
+  border-top: 0.1em dashed black;
+}
+
+.copyright {
+  text-align: center;
 }
 
 .footer-navigation {
-
-}
-
-.footer-branding {
-  max-width: 50%;
   margin: 0 auto;
-  padding-left: 4em;
+  max-width: 40ch;
 }
 
-
+.footer-navigation ul {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-around;
+}
 
 /* FOIL Overview */
 


### PR DESCRIPTION
Style the header `h1` to break up the long text, playing with size,
alignment, and decoration, to try to help make it digestible and "pop".

Consolidate some heading styles where we can leverage the cascade.

Generally center the footer elements, with various degrees of
sophistication for control.

Use `text-decoration` to implement the underline instead of
`border-bottom`. This achieves the same effect, and has two main benefits:

1. Links will wrap within the word, helping responsive behavior.
2. The underline will draw behind low dangling glyph segments, like
`g` or `j`, instead of appearing below the entire glyph, which better
reflects how we draw letters on lines.