### PR TITLE
Style navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,13 @@
     <body>
 
 <header>
-        <nav>
+        <nav class="menu">
             <details>
-                <summary>Menu</summary>
+                <summary>
+                    <svg class="icon__menu" role="img" viewBox="0 0 100 100" width="50" height="50" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#000" stroke-linejoin="round" stroke-miterlimit="10"><path d="m17 45h66v10h-66zm0 23h66v10h-66zm0-46h66v10h-66z" stroke-width="2"/><path d="m73.5 28.5h-56.5m61.5 0h-2m-50 46h56m-61 0h2m44-23h-45m56 0h-2m-3 0h-3" stroke-linecap="round"/></g></svg>
+                    <svg class="icon__close" role="img" viewBox="0 0 100 100" height="50" width="50" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#000" stroke-linejoin="round" stroke-miterlimit="10"><path d="m82 25.275-7.274-7.274-24.726 24.726-24.724-24.731-7.273 7.272 24.724 24.732-24.727 24.727 7.274 7.274 24.726-24.726 24.722 24.728 7.274-7.271-24.723-24.73z" stroke-width="2"/><path d="m73.5 73.5 1 1m-5-5 2 2m0-43-21.5 21.5 17.5 17.5m7-42-1 1m-47 0-1-1m5 5-2-2m0 43 21.5-21.5-17.5-17.5m-7 42 1-1" stroke-linecap="round"/></g></svg>
+                    <span class="accessibility-hidden">Menu</span>
+                </summary>
                 <ul>
                     <li><a href="/">How to file a Freedom of Information Law Request in New York State</a></li>
                     <li><a href="#request-overview">The FOIL Request Letter</a></li>

--- a/resources.html
+++ b/resources.html
@@ -14,9 +14,13 @@
     </head>
     <body>
     <header>
-        <nav>
+        <nav class="menu">
             <details>
-                <summary>Menu</summary>
+                <summary>
+                    <svg class="icon__menu" role="img" viewBox="0 0 100 100" width="50" height="50" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#000" stroke-linejoin="round" stroke-miterlimit="10"><path d="m17 45h66v10h-66zm0 23h66v10h-66zm0-46h66v10h-66z" stroke-width="2"/><path d="m73.5 28.5h-56.5m61.5 0h-2m-50 46h56m-61 0h2m44-23h-45m56 0h-2m-3 0h-3" stroke-linecap="round"/></g></svg>
+                    <svg class="icon__close" role="img" viewBox="0 0 100 100" height="50" width="50" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#000" stroke-linejoin="round" stroke-miterlimit="10"><path d="m82 25.275-7.274-7.274-24.726 24.726-24.724-24.731-7.273 7.272 24.724 24.732-24.727 24.727 7.274 7.274 24.726-24.726 24.722 24.728 7.274-7.271-24.723-24.73z" stroke-width="2"/><path d="m73.5 73.5 1 1m-5-5 2 2m0-43-21.5 21.5 17.5 17.5m7-42-1 1m-47 0-1-1m5 5-2-2m0 43 21.5-21.5-17.5-17.5m-7 42 1-1" stroke-linecap="round"/></g></svg>
+                    <span class="accessibility-hidden">Menu</span>
+                </summary>
                 <ul>
                     <li><a href="/">How to file a Freedom of Information Law Request in New York State</a></li>
                     <li><a href="#request-overview">The FOIL Request Letter</a></li>

--- a/style.css
+++ b/style.css
@@ -303,6 +303,36 @@ header {
 
 }
 
+/* Menu */
+
+.menu details > summary {
+  list-style: none;
+}
+
+.menu details > summary::-webkit-details-marker {
+  display: none;
+}
+
+summary:hover {
+  cursor: pointer;
+}
+
+.menu details[open] .icon__close {
+  display: block;
+}
+
+.icon__close,
+.menu details[open] .icon__menu {
+  display: none;
+}
+
+.accessibility-hidden {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+}
 
 /* Footer */ 
 


### PR DESCRIPTION
Keep it pretty simple; swap out the default indicator with a
hamburger/close SVG, and accessibly hide the Menu text for screen
readers.